### PR TITLE
stop if no certs available and tls verify reqested

### DIFF
--- a/sieve-connect.pre.pl
+++ b/sieve-connect.pre.pl
@@ -604,6 +604,15 @@ if (exists $capa{STARTTLS}) {
 		$ssl_options{'SSL_verifycn_scheme'} = 'http';
 	}
 
+	if ($ssl_options{'SSL_verify_mode'} != 0x00
+		and !exists $ssl_options{'SSL_ca_path'}
+		and !exists $ssl_options{'SSL_ca_file'}  ) {
+
+		print "No SSL_ca_file or SSL_ca_path found but tls verification requested.\n";
+		print "If you really want to connect without verification, use --notlsverify\n";
+		exit 1;
+	}
+
 	if ($DEBUGGING) {
 
 	debug("-T- will use TLS certs from " .


### PR DESCRIPTION
I ran into a behavior on OS X today, that I would consider undesirable. This is kind of a combined bug report / proposed improvement.

Versions:
OS X 10.11.1
openssl: OpenSSL 0.9.8zg 14 July 2015
The issue affectes sieve-connect 0.87 from homebrew as well as the version I based this fork on.

Short version:
openssl on OS X is broken in that is has no access to system provided trusted root CA certs.
sieve-connect  shows no warning when connecting to a server that presents a cert for a different hostname than is provided via `-s`.
I noticed this when after successfully connecting with sieve-connect the thunderbird sieve extension refused due to a certificate error when using a misconfigured server.
I believe this silent fallback to not checking the certificate is dangerous for users and should be considered a bug, even though the root cause might be Apple.

Details: 
`openssl version -d` returns `OPENSSLDIR: "/System/Library/OpenSSL"`, which
a) is empty
b)  on 10.11.1 is not writeable even as root. [1]

The autodiscovery code rejects the empty dir, no other locations that are checked are valid so in the end `$ssl_options{'SSL_ca_path'}` and `$ssl_options{'SSL_ca_file'}`are not set.
when running with `--debug` this also leads to this perl warning:
`Use of uninitialized value in concatenation (.) or string at ./sieve-connect line 609, <GEN2> line 7.
` and subsequent output of `-T- will use TLS certs from directory ""`

I hope I forgot nothing. Thank you for providing a nice, clean solution for simple SIEVE editing.

PS: I never did any serious perl before and do not expect this to to be the right way to handle the situation. Please feel free to modify the solution or do sth. else entirely. :D

[1] https://en.wikipedia.org/wiki/System_Integrity_Protection