### PR TITLE
Fix RE errors (will be fatal in perl 5.30).

### DIFF
--- a/sieve-connect.pre.pl
+++ b/sieve-connect.pre.pl
@@ -927,7 +927,7 @@ if (defined $realm) {
 		if (/^"(.*)"\r?\n?$/) {
 			$challenge = $1;
 		} else {
-			unless (/^{(\d+)\+?}\r?$/m) {
+			unless (/^\{(\d+)\+?}\r?$/m) {
 				sfinish $sock, "*";
 				closedie($sock, "Failure to parse server SASL response.\n");
 			}
@@ -1510,7 +1510,7 @@ sub sieve_download
 		warn qq{Empty script "$remotefn"?  Not saved.\n};
 		return;
 	}
-	unless (/^{(\d+)\+?}\r?$/m) {
+	unless (/^\{(\d+)\+?}\r?$/m) {
 		die "QUIT:Failed to parse server response to GETSCRIPT";
 	}
 	my $contentdata = $_;
@@ -1526,7 +1526,7 @@ sub sieve_download
 			or die "write-open($localfn) failed: $!\n";
 		$oldouthandle = select $fh;
 	}
-	$contentdata =~ s/^{\d+\+?}\r?\n?//m;
+	$contentdata =~ s/^\{\d+\+?}\r?\n?//m;
 	print $contentdata;
 	select $oldouthandle if defined $oldouthandle;
 	if (defined $fh) {


### PR DESCRIPTION
This fixes some errors in regexps:

Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), passed through in regex; marked by <-- HERE in m/^{ <-- HERE (\d+)\+?}\r?$/ at sieve-connect line 930.
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), passed through in regex; marked by <-- HERE in m/^{ <-- HERE (\d+)\+?}\r?$/ at sieve-connect line 1513.
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), passed through in regex; marked by <-- HERE in m/^{ <-- HERE \d+\+?}\r?\n?/ at sieve-connect line 1529.
